### PR TITLE
Repair shot-chart interaction and coverage contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,17 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [22.12.0, 24]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version-file: .nvmrc
+          node-version: ${{ matrix.node }}
           cache: npm
       - run: npm ci
       - run: npm run check
+      - run: npm run audit:production
       - run: npm run audit:dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# D3 NBA Hex Chart
+
+## Purpose
+
+This repository is a static React, D3, and TypeScript visualization backed by an immutable,
+repository-owned NBA shot snapshot. React owns page state, `src/shot-chart.ts` owns SVG rendering
+and inspection semantics, and `scripts/generate-hexes.mjs` owns deterministic data generation.
+
+## Canonical commands
+
+```sh
+npm ci
+npm run check
+npm run audit:production
+npm run audit:dependencies
+```
+
+`npm run check` verifies the source contract and generated artifact, runs the interaction and data
+tests, type-checks the project, and builds the static Vite artifact.
+
+## Data and rendering contract
+
+- `data/nba-shot-chart-processed.csv` and `data/shot-source.json` are the source authority.
+- `src/data-processed/hexes.json` is generated; change it only through `npm run data:generate`.
+- Preserve exact attempt/make conservation, deterministic bin ordering, the 15-pixel bin radius,
+  and the documented Ja Morant 2019-20 regular-season scope.
+- D3 owns SVG children. React owns the surrounding document and the inspected-bin status message.
+- Every shot hex must expose the same summary on pointer inspection and keyboard focus.
+- Keep out-of-frame source attempts in provenance totals and the explicit coverage note; do not
+  create invisible or off-canvas focus targets for them.
+- Do not append children to SVG paths, disable a path after interaction, or log shot records during
+  ordinary use.
+
+## Dependency and release contract
+
+- Node 22.12 is the minimum supported runtime; Node 24 is the current local and hosted line.
+- Keep production-only and complete dependency audits separate. Both use the repository's strict
+  low-severity threshold.
+- Renovate may group compatible non-major updates. Every major requires Dependency Dashboard
+  approval and still needs exact-head local and hosted validation before merge.
+- A successful build or deploy preview does not prove production publication.
+
+## Working rules
+
+- Preserve the local source snapshot and third-party rights boundary in the README and license.
+- Update README architecture, accessibility, dependency, and validation sections when their code
+  contracts change.
+- Stage only the intended paths; use an isolated worktree when the primary checkout is not clean.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# D3 NBA Hex Chart
+
+See [`./AGENTS.md`](./AGENTS.md) for the canonical repository contract. Keep this compatibility shim
+and the README aligned when data authority, interaction semantics, dependency gates, or release
+boundaries change.

--- a/README.md
+++ b/README.md
@@ -7,10 +7,15 @@ visualization.
 
 ## Architecture and data contract
 
-React owns the page lifecycle and SVG container. On mount, D3 draws the court
-and binds the generated records in `src/data-processed/hexes.json` to the chart.
-`d3-hexbin` generates each hexagon path, while the record's coordinates, shot
-zone, and field-goal-attempt count control its position, color, and size.
+React owns page state and the inspected-bin status message. The rendering module
+in `src/shot-chart.ts` owns the SVG lifecycle: D3 draws the court and binds the
+generated records in `src/data-processed/hexes.json` to the chart. `d3-hexbin`
+generates each atomic hexagon path, while the record's coordinates, shot zone,
+and field-goal-attempt count control its position, color, and size. The chart
+uses a fixed coordinate system inside a responsive SVG view box, so resizing the
+page does not reinterpret the source data. Bins outside that fixed plotting
+frame remain in provenance totals and are reported in a coverage note instead
+of becoming invisible or off-canvas focus targets.
 
 The application does not fetch live NBA data. Its repository authority is the
 937-row snapshot in `data/nba-shot-chart-processed.csv`, paired with the
@@ -43,8 +48,9 @@ Reference material:
 
 ## Local development
 
-Use Node.js 22.12.0 or newer and npm 11.19.0 (the version declared in
-`package.json`). Install the locked dependency graph before running the app:
+Use Node.js 22.12.0 or newer. Node 24 is the current local line in `.nvmrc`, and
+npm 11.19.0 is the package manager declared by `package.json`. Install the
+locked dependency graph before running the app:
 
 ```bash
 npm ci
@@ -60,21 +66,39 @@ Run the same local gates before committing or merging any change:
 
 ```bash
 npm run check
+npm run audit:production
 npm run audit:dependencies
 ```
 
 `npm run check` verifies generated-data freshness, runs the Vitest UI and
 preprocessing suites, type-checks the project, and creates the optimized,
-content-hashed static artifact in `dist`. CI repeats that contract from
-`npm ci`, then audits the complete locked dependency graph. Deployment is a
-separate operation; a successful build does not by itself confirm that `dist`
-was published.
+content-hashed static artifact in `dist`. CI repeats that contract from `npm ci`
+on Node 22.12 and Node 24. The production audit covers only code shipped to the
+browser; the complete audit also covers development and build tooling. Both use
+the low-severity threshold. Deployment is a separate operation; a successful
+build does not by itself confirm that `dist` was published.
+
+## Dependency update policy
+
+Renovate groups compatible non-major updates. Every major update—including the
+npm 12 runtime/tooling line—requires explicit Dependency Dashboard approval.
+Approval may open a compatibility PR; it does not authorize a merge. Each exact
+head must still pass the locked install, data contract, tests, build, both audit
+scopes, and hosted Node matrix without force or legacy-peer resolution.
 
 ## Accessibility and privacy
 
-The SVG has an accessible chart label, and every generated hex is keyboard
-focusable with its make/attempt/zone summary exposed to assistive technology.
-The site has no analytics, account, form, cookie, or live-data request.
+The SVG is a `graphics-document`, and every generated hex is an atomic
+`graphics-symbol` with a make/attempt/percentage label. The nine long-range
+attempts outside the plotting frame remain in the 937-attempt total and are
+reported separately. Pointer inspection and keyboard focus update the same
+visible polite status region; focus never moves to the status message. This
+follows the W3C
+[Graphics ARIA](https://www.w3.org/TR/graphics-aria-1.0/) role model and
+[`role=status`](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA22) guidance.
+The responsive SVG preserves keyboard focus and chart coordinates at narrow
+viewports. The site has no analytics, account, form, cookie, or live-data
+request.
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "7.0.1",
         "@testing-library/react": "16.3.2",
-        "@testing-library/user-event": "14.6.3",
+        "@testing-library/user-event": "14.6.4",
         "@types/d3": "7.4.3",
         "@types/d3-hexbin": "0.2.5",
         "@types/node": "26.2.0",
@@ -690,9 +690,9 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "14.6.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.3.tgz",
-      "integrity": "sha512-6dBq67jT8lE+JTE8Exm02Kt6ze43hz1jdiSpSJwtTZiT1xQQ6b7nZYTTQ9njdArdU8XklOwaDp/AbT/eYSKF4g==",
+      "version": "14.6.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.4.tgz",
+      "integrity": "sha512-QCGwP6QrjypBLwyj5cuyfVamkaIEy/XGY+1VDehbtbQqOggYmTFpFOdWR5mPz14vX8vXLMVjDHlRNBcClyO9ew==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "data:check": "node scripts/generate-hexes.mjs --check",
     "test": "vitest run",
     "check": "npm run data:check && npm test && npm run build",
+    "audit:production": "npm audit --omit=dev --audit-level=low",
     "audit:dependencies": "npm audit --audit-level=low",
     "preview": "vite preview"
   },
@@ -45,7 +46,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "7.0.1",
     "@testing-library/react": "16.3.2",
-    "@testing-library/user-event": "14.6.3",
+    "@testing-library/user-event": "14.6.4",
     "@types/d3": "7.4.3",
     "@types/d3-hexbin": "0.2.5",
     "@types/node": "26.2.0",

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "extends": ["config:recommended", "group:allNonMajor"],
+  "packageRules": [
+    {
+      "description": "Require compatibility review for every major update",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    }
+  ]
 }

--- a/src/App.css
+++ b/src/App.css
@@ -9,27 +9,28 @@
 #header .heading {
   font-family: "Source Sans Pro", sans-serif;
   font-weight: 700;
-  font-size: 5rem;
+  font-size: clamp(3rem, 9vw, 5rem);
   line-height: 1;
   color: #737aea;
-  margin-bottom: 0px;
+  margin-bottom: 0;
 }
 #header .about {
-  font-size: 2.5rem;
-  line-height: 1.35rem;
+  font-size: clamp(1.5rem, 5vw, 2.5rem);
+  line-height: 1.1;
   font-weight: 200;
   letter-spacing: -1.5px;
-  margin: 0px 0px 16px 0px;
+  margin: 0 0 16px;
 }
 /* Details */
 #header .details {
   display: flex;
   flex-direction: row;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
   align-content: center;
-  padding: 0px;
+  gap: 1rem 2rem;
+  padding: 0;
 }
 #header .details li {
   list-style: none;
@@ -42,12 +43,16 @@
   line-height: 1.5;
 }
 .container {
-  margin-top: 64.32px;
+  width: 100%;
+  max-width: 954px;
+  margin-top: 4rem;
 }
 
-svg {
-  display: flex;
-  overflow: visible;
+.court {
+  display: block;
+  width: 100%;
+  height: auto;
+  overflow: hidden;
 }
 
 .court-outline {
@@ -55,9 +60,55 @@ svg {
   stroke: #3b312b;
 }
 
-.hexbin:focus {
+.hexbin {
+  opacity: 0.4;
+  transition:
+    opacity 120ms ease,
+    stroke-width 120ms ease;
+}
+
+.hexbin[data-zone="2"] {
+  fill: #0047ff;
+}
+
+.hexbin[data-zone="3"] {
+  fill: #db00ff;
+}
+
+.hexbin:hover,
+.hexbin:focus-visible {
   opacity: 1 !important;
   outline: none;
   stroke: #111;
   stroke-width: 2px;
+}
+
+.coverage-note,
+.shot-details {
+  min-height: 1.5rem;
+  margin: 1.5rem 0 0;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.coverage-note {
+  color: #3b312b;
+}
+
+.shot-details {
+  font-weight: 600;
+}
+
+@media (max-width: 640px) {
+  #header .details {
+    justify-content: flex-start;
+  }
+
+  #header .details li {
+    flex: 1 1 9rem;
+  }
+
+  .container {
+    margin-top: 2rem;
+  }
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 
 import App from "./App";
@@ -11,11 +12,35 @@ describe("App", () => {
     expect(screen.getByText("Ja Morant")).toBeVisible();
     expect(screen.getByText("2019-20")).toBeVisible();
     expect(screen.getByText(/937 attempts, 447 makes, and 293/)).toBeVisible();
-    expect(
-      screen.getByRole("graphics-document", {
-        name: "Ja Morant 2019-20 Regular Season shot chart",
-      }),
-    ).toBeVisible();
-    expect(screen.getAllByRole("graphics-symbol")).toHaveLength(293);
+    const chart = screen.getByRole("graphics-document", {
+      name: "Ja Morant 2019-20 Regular Season shot chart",
+    });
+    expect(chart).toBeVisible();
+    expect(chart).toHaveAttribute("viewBox", expect.stringMatching(/^0 0 954 /));
+    expect(screen.getAllByRole("graphics-symbol")).toHaveLength(284);
+    const coverage = screen.getByText((_content, element) => element?.id === "chart-coverage");
+    expect(coverage).toHaveTextContent("9 long-range attempts across 9 bins sit outside it");
+  });
+
+  it("exposes the same shot summary to pointer and keyboard users", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    const sourceLink = screen.getByRole("link", { name: "NBA Stats" });
+    const firstHex = screen.getAllByRole("graphics-symbol")[0];
+    const status = screen.getByRole("status");
+
+    expect(status).toHaveTextContent("Focus or point at a shot hex");
+
+    await user.hover(firstHex);
+    expect(status).toHaveTextContent("0 makes on 1 attempt (0%) from 3-point range");
+    expect(firstHex).toBeEmptyDOMElement();
+    expect(firstHex).not.toHaveStyle({ pointerEvents: "none" });
+
+    await user.tab();
+    expect(sourceLink).toHaveFocus();
+    await user.tab();
+    expect(firstHex).toHaveFocus();
+    expect(status).toHaveTextContent("0 makes on 1 attempt (0%) from 3-point range");
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,234 +1,57 @@
 import * as React from "react";
+
 import "./App.css";
 import shotChartData from "./data-processed/hexes.json";
-import * as D3 from "d3";
-//https://github.com/d3/d3-hexbin
-//https://github.com/d3/d3-hexbin/issues/16
-import { hexbin as Hexbin } from "d3-hexbin";
-//https://www.stackoverflow.com/questions/50384029/cannot-import-d3-tip-or-d3-hexbin-into-react-component
-const d3 = {
-  ...D3,
-  hex: Hexbin,
-};
+import {
+  formatCoverageSummary,
+  formatShotSummary,
+  getChartCoverage,
+  renderShotChart,
+  type ShotHex,
+} from "./shot-chart";
 
 function App() {
   const svgRef = React.useRef<SVGSVGElement>(null);
+  const [inspectedHex, setInspectedHex] = React.useState<ShotHex | null>(null);
   const { metadata, hexes } = shotChartData;
+  const coverage = getChartCoverage(hexes);
 
   React.useEffect(() => {
-    const svg = D3.select(svgRef.current);
-    svg.selectAll("*").remove();
+    if (!svgRef.current) return;
 
-    const width = 954;
-    const height = width / 1.422475106685633;
-    const z = 20;
-    const margin = 10;
-    const x = D3.scaleLinear().domain([-250, 250]).range([0, width]);
-    const y = D3.scaleLinear().domain([-47.5, 304]).range([height, 0]);
-    const whratio =
-      (x.domain()[1] - x.domain()[0]) / (y.domain()[1] - y.domain()[0]);
-    const binRadius = 15;
-    const maxAttempts = D3.max(hexes, (bin) => bin.fga) ?? 1;
-    const size = D3.scaleSqrt()
-      .domain([1, maxAttempts])
-      .range([4, binRadius - 1])
-      .clamp(true);
-    const hexbin = d3
-      .hex()
-      .x(function (d: any) {
-        return x(d.x);
-      })
-      .y(function (d: any) {
-        return y(d.y);
-      })
-      .radius(binRadius);
-    //const color = d3
-    //  .scaleLinear()
-    //  .domain([0.05, 0.8])
-    //  .range(["steelblue", "brown"])
-    //  .interpolate(d3.interpolateHcl)
-    //  .clamp(true);
-
-    svg.attr("class", "court").attr("width", width).attr("height", height);
-
-    svg
-      .selectAll("path.hexbin")
-      .data(hexes)
-      .join((enter) =>
-        enter
-          .append("path")
-          .attr("class", "hexbin")
-          .attr("role", "graphics-symbol")
-          .attr("tabindex", 0)
-          .attr(
-            "aria-label",
-            (d) =>
-              `${d.fgm} ${d.fgm === 1 ? "make" : "makes"} on ${d.fga} ${
-                d.fga === 1 ? "attempt" : "attempts"
-              } in a ${d.zone}-point zone`,
-          )
-          .attr("d", (d) => hexbin.hexagon(size(d.fga)))
-          .attr("transform", (d) => `translate(${d.x},${d.y})`)
-          .style("opacity", 0.4)
-          .style("fill", (d) => (d.zone === "3" ? "#db00ff" : "#0047ff"))
-          .on("mouseenter", function (event, value) {
-            const index = svg.selectAll(".hexbin").nodes().indexOf(this);
-            console.log(event, index, Object.entries(value));
-            d3.select(this)
-              .style("pointer-events", "none")
-              .transition()
-              .duration(1000)
-              .attr("transform", "translate(480,480)scale(23)rotate(180)")
-              .call(() => {
-                d3.select(this)
-                  .append("text")
-                  .text(index)
-                  .attr("x", "477")
-                  .attr("y", "200")
-                  .attr("font-family", "sans-serif")
-                  .attr("font-size", "20px")
-                  .attr("fill", "black");
-              })
-              .transition()
-              .delay(1500)
-              .attr("transform", (d: any) => `translate(${d.x},${d.y})`)
-              .style("fill-opacity", 0.4);
-          })
-      );
-
-    function drawCourt(svgEL: any) {
-      svgEL
-        .append("line")
-        .attr("class", "court-outline baseline")
-        .attr("x1", x(-250))
-        .attr("y1", y(-15 / 2 - 40))
-        .attr("x2", x(250))
-        .attr("y2", y(-15 / 2 - 40));
-
-      svgEL
-        .append("circle")
-        .attr("class", "court-outline hoop")
-        .attr("cx", x(0))
-        .attr("cy", y(0))
-        .attr("r", (x(15) - x(0)) / 2);
-
-      svgEL
-        .append("line")
-        .attr("class", "court-outline backboard")
-        .attr("x1", x(30))
-        .attr("x2", x(-30))
-        .attr("y1", y(-8.5))
-        .attr("y2", y(-8.5));
-
-      svgEL
-        .append("line")
-        .attr("class", "court-outline three corner")
-        .attr("x1", x(218))
-        .attr("x2", x(218))
-        .attr("y1", y(-15 / 2 - 40 + 140))
-        .attr("y2", y(-15 / 2 - 40));
-
-      svgEL
-        .append("line")
-        .attr("class", "court-outline three corner")
-        .attr("x1", x(-218))
-        .attr("x2", x(-218))
-        .attr("y1", y(-15 / 2 - 40 + 140))
-        .attr("y2", y(-15 / 2 - 40));
-
-      const bSide = y(0) - y(-15 / 2 - 40 + 140);
-      const aSide = x(0) - x(-218);
-      const angle = Math.atan(bSide / aSide);
-      const hypot = Math.sqrt(bSide * bSide + aSide * aSide);
-
-      const tpArc = D3.arc()
-        .innerRadius(hypot)
-        .outerRadius(hypot)
-        .startAngle(-Math.PI / 2 + angle)
-        .endAngle(Math.PI / 2 - angle);
-
-      svgEL
-        .append("path")
-        .attr("d", tpArc)
-        .attr("class", "court-outline three arc")
-        .attr("transform", (d: any) => `translate(${x(0)},${y(0)})`);
-
-      //   // optional
-
-      //   svgEL.append("rect")
-      //     .attr('class', 'court-outline key')
-      //     .attr('x', x(-80))
-      //     .attr('y', y(-15/2 - 40 + 190))
-      //     .attr('width', x(160) - x(0))
-      //     .attr('height', y(0) - y(190))
-
-      //   var ftArcTop = D3.arc()
-      //     .innerRadius(x(60) - x(0))
-      //     .outerRadius(x(60) - x(0))
-      //     .startAngle(-Math.PI/2)
-      //     .endAngle(Math.PI/2)
-
-      //   svgEL.append('path')
-      //     .attr('class', 'court-outline ftcircle top')
-      //     .attr('d', ftArcTop)
-      //     .attr("transform", d => `translate(${x(0)},${y(0-15/2-40+190)})`)
-
-      //   var ftArcBottom = D3.arc()
-      //     .innerRadius(x(60) - x(0))
-      //     .outerRadius(x(60) - x(0))
-      //     .startAngle(Math.PI/2)
-      //     .endAngle(3*Math.PI/2)
-
-      //   svgEL.append('path')
-      //     .attr('class', 'court-outline ftcircle bottom')
-      //     .attr('d', ftArcBottom)
-      //     .attr('stroke-dasharray', '20')
-      //     .attr("transform", d => `translate(${x(0)},${y(0-15/2-40+190)})`)
-
-      //   var raArc = D3.arc()
-      //     .innerRadius(x(40) - x(0))
-      //     .outerRadius(x(40) - x(0))
-      //     .startAngle(-Math.PI/2)
-      //     .endAngle(Math.PI/2)
-
-      //   svgEL.append('path')
-      //     .attr('class', 'court-outline rarea')
-      //     .attr('d', raArc)
-      //     .attr("transform", d => `translate(${x(0)},${y(0)})`)
-    }
-
-    drawCourt(svg);
+    return renderShotChart({
+      svgElement: svgRef.current,
+      hexes,
+      onInspect: setInspectedHex,
+    });
   }, [hexes]);
 
   return (
     <>
       <header id="header">
         <h1 className="heading">NBA SHOT CHART</h1>
-        <p className="about">
-          ... mapping out NBA player's shot chart per season.
-        </p>
+        <p className="about">... mapping out an NBA player&apos;s shot chart per season.</p>
         <ul className="details">
-          <li className="">
+          <li>
             Player
             <br /> <strong>{metadata.player}</strong>
           </li>
-          <li className="">
+          <li>
             Season
             <br /> <strong>{metadata.season}</strong>
           </li>
-          <li className="">
+          <li>
             Season Type
             <br /> <strong>{metadata.seasonType}</strong>
           </li>
-          <li className="">
+          <li>
             Field Goal Type
             <br /> <strong>{metadata.metric}</strong>
           </li>
         </ul>
         <p className="data-summary">
-          {metadata.attempts} attempts, {metadata.makes} makes, and {hexes.length}{" "}
-          deterministic hex bins. Source snapshot checked against{" "}
-          <a href={metadata.source.url}>NBA Stats</a>.
+          {metadata.attempts} attempts, {metadata.makes} makes, and {hexes.length} deterministic hex
+          bins. Source snapshot checked against <a href={metadata.source.url}>NBA Stats</a>.
         </p>
       </header>
 
@@ -237,7 +60,16 @@ function App() {
           ref={svgRef}
           role="graphics-document"
           aria-label={`${metadata.player} ${metadata.season} ${metadata.seasonType} shot chart`}
-        ></svg>
+          aria-describedby="chart-coverage shot-details"
+        />
+        <p id="chart-coverage" className="coverage-note">
+          {formatCoverageSummary(coverage, metadata.attempts)}
+        </p>
+        <p id="shot-details" className="shot-details" role="status" aria-atomic="true">
+          {inspectedHex
+            ? formatShotSummary(inspectedHex)
+            : "Focus or point at a shot hex to inspect its makes, attempts, and percentage."}
+        </p>
       </div>
     </>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -1,10 +1,13 @@
 body {
-  height: 100vh;
+  min-height: 100vh;
   margin: 0;
-  display: grid;
-  place-items: center;
   padding: 1rem;
   font-family: "Roboto", sans-serif;
+}
+
+#root {
+  width: min(100%, 1100px);
+  margin: 0 auto;
 }
 
 code {

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,1 +1,5 @@
 import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(cleanup);

--- a/src/shot-chart.test.ts
+++ b/src/shot-chart.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import shotChartData from "./data-processed/hexes.json";
+import { formatCoverageSummary, getChartCoverage } from "./shot-chart";
+
+describe("shot-chart coverage", () => {
+  it("keeps every out-of-frame attempt in the provenance total", () => {
+    const coverage = getChartCoverage(shotChartData.hexes);
+    const visibleAttempts = coverage.visible.reduce((total, hex) => total + hex.fga, 0);
+    const visibleMakes = coverage.visible.reduce((total, hex) => total + hex.fgm, 0);
+
+    expect(coverage.visible).toHaveLength(284);
+    expect(coverage.outside).toHaveLength(9);
+    expect(coverage.outsideAttempts).toBe(9);
+    expect(coverage.outsideMakes).toBe(0);
+    expect(visibleAttempts + coverage.outsideAttempts).toBe(shotChartData.metadata.attempts);
+    expect(visibleMakes + coverage.outsideMakes).toBe(shotChartData.metadata.makes);
+    expect(formatCoverageSummary(coverage, shotChartData.metadata.attempts)).toBe(
+      "284 bins fit the fixed plotting frame. 9 long-range attempts across 9 bins sit outside it and remain included in the 937-attempt total.",
+    );
+  });
+});

--- a/src/shot-chart.ts
+++ b/src/shot-chart.ts
@@ -1,0 +1,181 @@
+import * as D3 from "d3";
+import { hexbin } from "d3-hexbin";
+
+export const CHART_WIDTH = 954;
+export const CHART_HEIGHT = CHART_WIDTH / 1.422475106685633;
+const HEX_RADIUS = 15;
+
+export type ShotHex = {
+  x: number;
+  y: number;
+  fga: number;
+  fgm: number;
+  pct: number;
+  zone: string;
+};
+
+type ChartOptions = {
+  svgElement: SVGSVGElement;
+  hexes: readonly ShotHex[];
+  onInspect: (hex: ShotHex) => void;
+};
+
+type SvgSelection = D3.Selection<SVGSVGElement, unknown, null, undefined>;
+
+export type ChartCoverage = {
+  visible: ShotHex[];
+  outside: ShotHex[];
+  outsideAttempts: number;
+  outsideMakes: number;
+};
+
+const pluralize = (count: number, singular: string, plural = `${singular}s`) =>
+  count === 1 ? singular : plural;
+
+export function formatShotSummary(hex: ShotHex) {
+  const percentage = new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 1,
+    style: "percent",
+  }).format(hex.pct);
+
+  return `${hex.fgm} ${pluralize(hex.fgm, "make")} on ${hex.fga} ${pluralize(
+    hex.fga,
+    "attempt",
+  )} (${percentage}) from ${hex.zone}-point range`;
+}
+
+export function getChartCoverage(hexes: readonly ShotHex[]): ChartCoverage {
+  const visible: ShotHex[] = [];
+  const outside: ShotHex[] = [];
+
+  for (const hex of hexes) {
+    const collection =
+      hex.x >= 0 && hex.x <= CHART_WIDTH && hex.y >= 0 && hex.y <= CHART_HEIGHT
+        ? visible
+        : outside;
+    collection.push(hex);
+  }
+
+  return {
+    visible,
+    outside,
+    outsideAttempts: outside.reduce((total, hex) => total + hex.fga, 0),
+    outsideMakes: outside.reduce((total, hex) => total + hex.fgm, 0),
+  };
+}
+
+export function formatCoverageSummary(coverage: ChartCoverage, totalAttempts: number) {
+  const outsideAttempts = `${coverage.outsideAttempts} ${pluralize(
+    coverage.outsideAttempts,
+    "long-range attempt",
+  )}`;
+  const outsideBins = `${coverage.outside.length} ${pluralize(coverage.outside.length, "bin")}`;
+  const outsideMakes =
+    coverage.outsideMakes > 0
+      ? `, including ${coverage.outsideMakes} ${pluralize(coverage.outsideMakes, "make")}`
+      : "";
+
+  return `${coverage.visible.length} bins fit the fixed plotting frame. ${outsideAttempts} across ${outsideBins} ${
+    coverage.outside.length === 1 ? "sits" : "sit"
+  } outside it and remain included in the ${totalAttempts}-attempt total${outsideMakes}.`;
+}
+
+function drawCourt(
+  svg: SvgSelection,
+  x: D3.ScaleLinear<number, number>,
+  y: D3.ScaleLinear<number, number>,
+) {
+  svg
+    .append("line")
+    .attr("class", "court-outline baseline")
+    .attr("x1", x(-250))
+    .attr("y1", y(-47.5))
+    .attr("x2", x(250))
+    .attr("y2", y(-47.5));
+
+  svg
+    .append("circle")
+    .attr("class", "court-outline hoop")
+    .attr("cx", x(0))
+    .attr("cy", y(0))
+    .attr("r", (x(15) - x(0)) / 2);
+
+  svg
+    .append("line")
+    .attr("class", "court-outline backboard")
+    .attr("x1", x(30))
+    .attr("x2", x(-30))
+    .attr("y1", y(-8.5))
+    .attr("y2", y(-8.5));
+
+  const cornerTop = -47.5 + 140;
+  for (const position of [-218, 218]) {
+    svg
+      .append("line")
+      .attr("class", "court-outline three corner")
+      .attr("x1", x(position))
+      .attr("x2", x(position))
+      .attr("y1", y(cornerTop))
+      .attr("y2", y(-47.5));
+  }
+
+  const opposite = y(0) - y(cornerTop);
+  const adjacent = x(0) - x(-218);
+  const angle = Math.atan(opposite / adjacent);
+  const radius = Math.hypot(opposite, adjacent);
+  const threePointArc = D3.arc()({
+    innerRadius: radius,
+    outerRadius: radius,
+    startAngle: -Math.PI / 2 + angle,
+    endAngle: Math.PI / 2 - angle,
+  });
+
+  svg
+    .append("path")
+    .attr("d", threePointArc)
+    .attr("class", "court-outline three arc")
+    .attr("transform", `translate(${x(0)},${y(0)})`);
+}
+
+export function renderShotChart({ svgElement, hexes, onInspect }: ChartOptions) {
+  const svg = D3.select(svgElement);
+  svg.selectAll("*").remove();
+  const { visible } = getChartCoverage(hexes);
+
+  const x = D3.scaleLinear().domain([-250, 250]).range([0, CHART_WIDTH]);
+  const y = D3.scaleLinear().domain([-47.5, 304]).range([CHART_HEIGHT, 0]);
+  const maxAttempts = D3.max(hexes, (hex) => hex.fga) ?? 1;
+  const size = D3.scaleSqrt()
+    .domain([1, maxAttempts])
+    .range([4, HEX_RADIUS - 1])
+    .clamp(true);
+  const path = hexbin<ShotHex>().radius(HEX_RADIUS);
+
+  svg
+    .attr("class", "court")
+    .attr("width", CHART_WIDTH)
+    .attr("height", CHART_HEIGHT)
+    .attr("viewBox", `0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`)
+    .attr("preserveAspectRatio", "xMidYMid meet");
+
+  drawCourt(svg, x, y);
+
+  svg
+    .selectAll<SVGPathElement, ShotHex>("path.hexbin")
+    .data(visible, (hex) => `${hex.x}:${hex.y}:${hex.zone}`)
+    .join("path")
+    .attr("class", "hexbin")
+    .attr("role", "graphics-symbol")
+    .attr("tabindex", 0)
+    .attr("aria-controls", "shot-details")
+    .attr("aria-label", formatShotSummary)
+    .attr("d", (hex) => path.hexagon(size(hex.fga)))
+    .attr("transform", (hex) => `translate(${hex.x},${hex.y})`)
+    .attr("data-zone", (hex) => hex.zone)
+    .on("pointerenter", (_event, hex) => onInspect(hex))
+    .on("focus", (_event, hex) => onInspect(hex));
+
+  return () => {
+    svg.selectAll("*").remove();
+  };
+}


### PR DESCRIPTION
Closes #116.

## Why

The chart mixed React state, D3 mutation, court geometry, and interaction behavior in one component. Its hover handler disabled the inspected path, logged shot data, appended invalid SVG content inside a `<path>`, and had no keyboard-equivalent result. Nine long-range bins were also rendered above the SVG view box, where they floated over the page header and remained off-canvas focus targets.

## What changed

- move SVG geometry, rendering, coverage partitioning, and summary formatting into `src/shot-chart.ts`
- replace the destructive hover animation with one shared inspection contract for pointer entry and keyboard focus
- expose each in-frame bin as a labeled `graphics-symbol` controlled by a visible polite status region
- preserve all 937 attempts and 447 makes while rendering only the 284 bins inside the fixed plotting frame
- report the nine out-of-frame long-range attempts explicitly instead of creating invisible/off-canvas focus targets
- make the SVG and header responsive without changing source coordinates or deterministic binning
- remove ordinary-use console logging, invalid path children, unused geometry, and post-hover pointer disabling
- add explicit Testing Library cleanup plus pointer, keyboard, coverage-conservation, and rendering tests
- update `@testing-library/user-event` from 14.6.3 to 14.6.4
- add separate production and complete low-severity audits
- validate Node 22.12 and Node 24 in hosted CI
- gate every dependency major behind Dependency Dashboard approval
- add canonical AGENTS/CLAUDE guidance and refine README architecture, accessibility, dependency, and release contracts

## Standards basis

The interaction follows the W3C [Graphics ARIA](https://www.w3.org/TR/graphics-aria-1.0/) model for structured graphics and the W3C [ARIA22 status technique](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA22) for advisory updates that do not steal focus.

## User and developer impact

Pointer and keyboard users receive the same make/attempt/percentage summary. Long-range source attempts remain auditable without overlapping the page header. The rendering module has an explicit typed boundary and no `any`, console logging, or invalid SVG mutation.

The optimized JavaScript artifact falls from approximately 492 KB / 159 KB gzip to 266 KB / 84 KB gzip because Vite can now retain only the D3 primitives used by the rendering module.

## Validation

- clean `npm ci`: 197 packages
- `npm run check`: deterministic data contract, 3 suites / 8 tests, TypeScript project build, and Vite production build pass
- `npm run audit:production`: 0 vulnerabilities at the low threshold
- `npm run audit:dependencies`: 0 vulnerabilities at the low threshold
- `npm outdated --json`: `{}`
- official Renovate configuration validation: passes
- `git diff --check`: passes
- desktop visual review: 284 in-frame paths, zero off-top paths, no horizontal overflow, and no application console warnings/errors
- 390px visual review: 343px responsive SVG, 375px document width, no horizontal overflow, preserved coverage note and chart geometry

## Non-scope

- no source CSV, provenance contract, generated JSON, player-season identity, 15-pixel bin radius, or attempt/make total changed
- no production deployment is authorized or claimed

## Risk and rollback

The main risk is a presentation change for the nine out-of-frame bins: they are now summarized rather than painted over unrelated page content. Their attempts and makes remain covered by an exact conservation test. Rollback is a single revert of this commit.

## Review focus

- pointer and keyboard inspection parity
- visible/out-of-frame conservation boundary
- D3 cleanup ownership under React
- responsive SVG behavior
- CI audit and major-update policy