### PR TITLE
Fix Nano ID CVE-2026-67213

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2617,9 +2617,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## What changed

Refresh the locked development-only Nano ID package from 3.3.17 to 3.3.18. No declared dependency or other lock entry changes.

## Why

Nano ID 3.3.17 is affected by CVE-2026-67213. The existing Vite/PostCSS graph accepts the fixed release.

## Impact

Runtime dependencies, generated shot data, rendering, and accessibility behavior are unchanged.

## Validation

- `npm ci --ignore-scripts` — 0 vulnerabilities
- `npm run check` — provenance current, 3 test files / 8 tests passed, TypeScript and Vite build passed
- `npm run audit:production` — 0 vulnerabilities
- `npm run audit:dependencies` — 0 vulnerabilities
- `git diff --check`

## Rollback

Reverting the lock change restores the vulnerable development package and is not recommended.
